### PR TITLE
Upgrade requirements in manifest.json

### DIFF
--- a/custom_components/miio2/__init__.py
+++ b/custom_components/miio2/__init__.py
@@ -1,1 +1,1 @@
-
+"""Support for Xiaomi Mi Robot Vacuum-Mop Pro."""

--- a/custom_components/miio2/manifest.json
+++ b/custom_components/miio2/manifest.json
@@ -1,11 +1,11 @@
 {
   "domain": "miio2",
   "name": "Xiaomi miio vacuum STYJ02YM",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "documentation": "https://github.com/KrzysztofHajdamowicz/home-assistant-vacuum-styj02ym",
   "requirements": [
-    "construct==2.9.45",
-    "python-miio==0.5.3"
+    "construct==2.10.56",
+    "python-miio>=0.5.4"
   ],
   "dependencies": [],
   "codeowners": ["@nqkdev", "@KrzysztofHajdamowicz"],

--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,10 @@
-
 {
     "name": "vacuum-styj02ym",
     "country": ["FR", "PL"],
     "domains": ["vacuum"],
-    "homeassistant": "0.109.0",
-    "iot_class": "local_poll",
+    "iot_class": "Local Polling",
+    "content_in_root": false,
+    "render_readme": false,
     "zip_release": true,
     "filename": "miio2.zip"
 }


### PR DESCRIPTION
There is a conflict with another HACS repository (https://github.com/syssi/xiaomi_airpurifier).
Using both platforms **xiaomi_miio_airpurifier** and **miio2** caused error with  xiaomi_miio_airpurifier which uses newer version of python-miio.

```
Platform error fan.xiaomi_miio_airpurifier - cannot import name 'FanMiot' from 'miio' (/usr/local/lib/python3.8/site-packages/miio/__init__.py)
```
(more here: https://github.com/syssi/xiaomi_airpurifier/issues/98)

This PR resolves this issue.